### PR TITLE
docs: add CLAUDE.md for AI assistant context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## About the flowimds repository
+
+flowimds is the open-source image-processing pipeline library that provides reusable pipelines for directories, file lists, or in-memory NumPy arrays. Compose steps like resizing, grayscale conversion, rotations, flips, binarization, and denoising, then run them as batch jobs that mirror the input folder hierarchy or flatten outputs into a single directory. The project targets Python 3.12+, ships under the MIT License, and is published on PyPI for easy installation.
+
+## Directory structure
+
+- `flowimds/` – Core package modules, including the pipeline orchestration logic, reusable step implementations, and utilities.
+- `docs/` – Documentation set (English and Japanese), contribution guides, and assets used across README variants.
+- `tests/` – Unit and integration suites plus shared fixtures for validating pipeline behaviors.
+- `samples/` – Lightweight usage examples demonstrating how to compose and run pipelines.
+- `scripts/` – Helper tooling for benchmarking, generating release notes, and creating deterministic test data.
+- `.devcontainer/` – Development container definition (Dockerfile and devcontainer.json) for a reproducible VS Code / Codespaces environment.
+- `.github/` – Issue/PR templates plus CI workflows that run publishing and validation pipelines.
+
+## Development Flow (TDD)
+
+1. Start by writing or updating a failing test (unit or integration) that captures the desired behavior.
+2. Run `uv run pytest` to confirm the test fails for the right reason.
+3. Implement the minimal production code to satisfy the new test while keeping style guides in mind.
+4. Run the same commands CI executes (`uv run ruff check .`, `uv run mypy`, `uv run pytest`, `uv run pip-audit`) and include the formatter (`uv run black --check .`) so local results match pipeline expectations.
+5. Once all checks succeed, commit and push using the semantic message format below.
+
+## Commit Messages
+
+- Use semantic commit messages written in English, keeping the imperative present tense (e.g., `feat: add grayscale step`, `fix: handle empty pipeline config`), and commit in small, focused increments so reviews stay easy to follow.
+
+
+## Other instructions
+- All comments in code are written in English.

--- a/uv.lock
+++ b/uv.lock
@@ -182,11 +182,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.20.1"
+version = "3.20.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/23/ce7a1126827cedeb958fc043d61745754464eb56c5937c35bbf2b8e26f34/filelock-3.20.1.tar.gz", hash = "sha256:b8360948b351b80f420878d8516519a2204b07aefcdcfd24912a5d33127f188c", size = 19476, upload-time = "2025-12-15T23:54:28.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/7f/a1a97644e39e7316d850784c642093c99df1290a460df4ede27659056834/filelock-3.20.1-py3-none-any.whl", hash = "sha256:15d9e9a67306188a44baa72f569d2bfd803076269365fdea0934385da4dc361a", size = 16666, upload-time = "2025-12-15T23:54:26.874Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add CLAUDE.md file by copying contents from AGENTS.md
- Provides context for Claude AI assistant about the repository

## Test plan
- [ ] Verify CLAUDE.md file exists and contains correct content
- [ ] Confirm file matches AGENTS.md content

🤖 Generated with [Claude Code](https://claude.com/claude-code)